### PR TITLE
Add readme and issue template for language learning page

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,55 @@
+name: Bug report
+description: Report a problem with content, data, tooling, or the site
+labels: [bug]
+title: "[bug] <short description>"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for reporting a bug. Please provide clear steps and affected language(s).
+  - type: input
+    id: area
+    attributes:
+      label: Area
+      description: What area is affected?
+      placeholder: content | linguistics profile | tools | build | site
+  - type: input
+    id: languages
+    attributes:
+      label: Language(s)
+      description: ISO code(s) and names
+      placeholder: es (Spanish), zh-Hans (Simplified Chinese)
+  - type: input
+    id: level_unit
+    attributes:
+      label: Level / Unit
+      placeholder: A1 / Unit 03
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: 1) Go to ... 2) Open ... 3) See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior / screenshots
+  - type: textarea
+    id: details
+    attributes:
+      label: Additional details
+      placeholder: Logs, links, references, sources
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: I searched existing issues
+          required: true
+        - label: I can work on a fix
+          required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & discussions
+    url: https://github.com/OWNER/REPO/discussions
+    about: Ask questions, share ideas, or request guidance here

--- a/.github/ISSUE_TEMPLATE/content_request.yml
+++ b/.github/ISSUE_TEMPLATE/content_request.yml
@@ -1,0 +1,50 @@
+name: Content request
+description: Request new lessons, exercises, or improvements
+labels: [enhancement, content]
+title: "[content] <language> <level> <unit>: <short description>"
+body:
+  - type: input
+    id: languages
+    attributes:
+      label: Language(s)
+      placeholder: fr (French)
+    validations:
+      required: true
+  - type: input
+    id: level
+    attributes:
+      label: Level
+      placeholder: A0 | A1 | A2 | B1 | B2
+    validations:
+      required: true
+  - type: input
+    id: unit
+    attributes:
+      label: Unit (if applicable)
+      placeholder: Unit 04
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      placeholder: What content is needed and why?
+    validations:
+      required: true
+  - type: textarea
+    id: details
+    attributes:
+      label: Details
+      placeholder: Outline lesson objectives, vocab themes, grammar targets, assessment ideas
+  - type: textarea
+    id: references
+    attributes:
+      label: References / sources
+      placeholder: Frequency lists, corpora, textbooks, grammar references
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: I checked the roadmap and existing content
+          required: true
+        - label: I can contribute this content
+          required: false

--- a/.github/ISSUE_TEMPLATE/translation_request.yml
+++ b/.github/ISSUE_TEMPLATE/translation_request.yml
@@ -1,0 +1,38 @@
+name: Translation request
+description: Request translation/localization of existing content
+labels: [translation]
+title: "[translation] <from> → <to>: <short description>"
+body:
+  - type: input
+    id: source
+    attributes:
+      label: Source language
+      placeholder: en (English)
+    validations:
+      required: true
+  - type: input
+    id: target
+    attributes:
+      label: Target language
+      placeholder: zh-Hans (Simplified Chinese)
+    validations:
+      required: true
+  - type: input
+    id: scope
+    attributes:
+      label: Scope
+      placeholder: Unit 02, dialogues + vocab
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes for translators
+      placeholder: Terminology, style preferences, register, IPA conventions
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: I verified the source content exists
+          required: true
+        - label: I can review the translation
+          required: false

--- a/README.md
+++ b/README.md
@@ -1,2 +1,83 @@
-# tickets
-CapySchool support
+# Multilingual Linguistics Learning (45 Languages)
+
+A comprehensive, linguistics-focused learning hub covering 45 languages. This project emphasizes phonetics, morphology, syntax, semantics, pragmatics, orthography, and sociolinguistics—paired with practical learner materials (vocabulary decks, graded readers, dialogues, exercises, and assessments).
+
+## Goals
+- Provide parallel, consistently-structured learning tracks across 45 languages
+- Emphasize linguistic insight (sound systems, grammar typology, scripts) to accelerate learning
+- Offer scaffolded content from A0 to B2 with clear outcomes and assessments
+- Enable community contributions for content, corrections, and translations
+
+## Structure
+- `content/` – core lessons, dialogues, vocabulary, exercises
+- `linguistics/` – language profiles (phonology, morphology, syntax, semantics, pragmatics)
+- `assets/` – audio, images, IPA charts, scripts, handwriting guides
+- `tools/` – generation scripts, validation, QA checks
+- `data/` – word lists, frequency data, lemma mappings, morphology paradigms
+- `guides/` – contributor guides, style guides, language-specific notes
+
+## Language Coverage (sample)
+Arabic, Mandarin Chinese, English, Spanish, French, German, Portuguese, Russian, Japanese, Korean, Hindi, Bengali, Punjabi, Turkish, Vietnamese, Thai, Indonesian, Malay, Filipino, Swahili, Amharic, Yoruba, Hausa, Zulu, Xhosa, Afrikaans, Italian, Dutch, Polish, Czech, Slovak, Ukrainian, Romanian, Greek, Hebrew, Persian, Urdu, Tamil, Telugu, Kannada, Malayalam, Marathi, Gujarati, Nepali, Burmese, Khmer, Lao. Target: 45 total; expand via issues/PRs.
+
+## Content Model
+Each language track follows a uniform schema:
+- Levels: `A0`, `A1`, `A2`, `B1`, `B2`
+- Units: 8–12 per level, with learning objectives
+- For each unit:
+  - Lesson overview and outcomes
+  - Dialogue(s) with translations and notes
+  - Vocabulary list with POS, lemma, frequency band, example sentence
+  - Grammar notes with typological pointers
+  - Pronunciation notes with IPA, minimal pairs, prosody cues
+  - Exercises (MCQ, cloze, production) with answer keys
+  - Assessment (unit quiz)
+
+## Linguistics Profiles
+For each language in `linguistics/<lang>/profile.md`:
+- Phonology: phoneme inventory, allophony, syllable structure, stress/tones, IPA
+- Morphology: inflection, derivation, productivity, paradigm examples
+- Syntax: word order, agreement, case, clause types, subordination
+- Semantics & Pragmatics: polysemy, particles, implicature, politeness systems
+- Orthography: script(s), grapheme-phoneme mapping, diacritics, romanization
+- Sociolinguistics: registers, dialects, diglossia, code-switching
+
+## Contribution
+We welcome contributions for:
+- New or improved lessons, exercises, and assessments
+- Corrections to linguistics profiles
+- Audio recordings and assets
+- Translations of existing content into additional target languages
+
+### How to Contribute
+1. Fork the repository and create a branch: `feat/lang-xx-unit-01` or `fix/phonology-xx`
+2. Follow the style guides in `guides/`
+3. Validate content using `tools/validate` (see below)
+4. Open a Pull Request describing scope, language, level, and unit numbers
+
+### Content Style Guidelines (essentials)
+- Use IPA for phonetic transcriptions; include minimal pairs when relevant
+- Keep glossing consistent (e.g., Leipzig Glossing Rules for interlinear examples)
+- Include difficulty tags and CEFR alignment
+- Provide sources for claims in linguistics notes when non-obvious
+
+## Tooling
+- Validation: `tools/validate` checks schema, metadata completeness, and link integrity
+- Linting: `tools/lint` checks formatting, IPA validity, and glossary consistency
+- Build: `tools/build` compiles content to site/static formats
+
+## Directory Conventions
+- Language codes use ISO 639-1/2 where possible (e.g., `es`, `pt-BR`, `zh-Hans`)
+- Use kebab-case for filenames; avoid spaces
+- Keep media lightweight; prefer compressed audio (e.g., `opus`, `mp3` at 96–128 kbps)
+
+## Roadmap
+- Fill minimum viable tracks for 10 languages (A0–A2)
+- Add B-level content and assessments
+- Expand to full 45-language coverage
+- Integrate TTS/ASR helpers for practice
+
+## Licensing
+Specify the license here (e.g., CC BY-SA 4.0 for content, MIT/Apache-2.0 for code). Include attribution requirements for assets where applicable.
+
+## Acknowledgements
+Thanks to linguists, teachers, and native speakers who contribute content and review.


### PR DESCRIPTION
Add comprehensive README and GitHub issue templates to establish project guidelines and streamline contributions.

---
<a href="https://cursor.com/background-agent?bcId=bc-09cca169-f039-49fd-b90a-e048d92bcb87">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-09cca169-f039-49fd-b90a-e048d92bcb87">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

